### PR TITLE
Debounce foreground process detection and harden hook setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = when_multiline:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+dotnet_style_require_accessibility_modifiers = always:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+[*.{csproj,props,targets}]
+indent_style = space
+indent_size = 2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can add exceptions for which applications are never muted.
 * Minimize to tray icon
 * Dark Mode
 * Debounced foreground detection to reduce rapid mute/unmute flicker during fast app switching
+* Pause-on-unfocus design notes and glossary are documented in `docs/pause_on_unfocus_design.md` and `docs/glossary.md`
 
 # Requirements
 * Requires DotNet 8.0 to work (install here https://dotnet.microsoft.com/en-us/download/dotnet/8.0)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ You can add exceptions for which applications are never muted.
 * Works out of the box with default settings
 * Add exceptions for applications to never be muted
 * Minimize to tray icon
-* Dark Mode 
+* Dark Mode
+* Debounced foreground detection to reduce rapid mute/unmute flicker during fast app switching
 
 # Requirements
 * Requires DotNet 8.0 to work (install here https://dotnet.microsoft.com/en-us/download/dotnet/8.0)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ You can add exceptions for which applications are never muted.
 # Requirements
 * Requires DotNet 8.0 to work (install here https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 
+# Development
+* Nullable reference types are enabled and Roslyn analyzers run with the `latest-recommended` ruleset (see `Directory.Build.props`).
+* Formatting defaults are enforced via `.editorconfig` (spaces, 4-space indents for C#, sorted `using` directives).
+
 # Getting Started
  - Download **WinBGMuter.zip** from the [Releases](https://github.com/nefares/Background-Muter/releases/latest) page, extract it and open the extracted folder (see image below)
  - Run **WinBGMuter.exe**. The application will automatically start muting background processes with default settings.

--- a/WinBGMute/Abstractions/Audio/AudioProcessState.cs
+++ b/WinBGMute/Abstractions/Audio/AudioProcessState.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace WinBGMuter.Abstractions.Audio
+{
+    public sealed class AudioProcessState
+    {
+        public AudioProcessState(int processId, string processName, bool isActive, float peak, DateTime lastSeenUtc)
+        {
+            ProcessId = processId;
+            ProcessName = processName;
+            IsActive = isActive;
+            Peak = peak;
+            LastSeenUtc = lastSeenUtc;
+        }
+
+        public int ProcessId { get; }
+
+        public string ProcessName { get; }
+
+        public bool IsActive { get; }
+
+        public float Peak { get; }
+
+        public DateTime LastSeenUtc { get; }
+    }
+}

--- a/WinBGMute/Abstractions/Audio/AudioSessionSnapshot.cs
+++ b/WinBGMute/Abstractions/Audio/AudioSessionSnapshot.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace WinBGMuter.Abstractions.Audio
+{
+    public sealed class AudioSessionSnapshot
+    {
+        public AudioSessionSnapshot(DateTime timestampUtc, IReadOnlyCollection<AudioProcessState> processes)
+        {
+            TimestampUtc = timestampUtc;
+            Processes = processes;
+        }
+
+        public DateTime TimestampUtc { get; }
+
+        public IReadOnlyCollection<AudioProcessState> Processes { get; }
+    }
+}

--- a/WinBGMute/Abstractions/Audio/IAudioSessionScanner.cs
+++ b/WinBGMute/Abstractions/Audio/IAudioSessionScanner.cs
@@ -1,0 +1,7 @@
+namespace WinBGMuter.Abstractions.Audio
+{
+    public interface IAudioSessionScanner
+    {
+        AudioSessionSnapshot CaptureSnapshot();
+    }
+}

--- a/WinBGMute/Abstractions/Foreground/ForegroundChangedEventArgs.cs
+++ b/WinBGMute/Abstractions/Foreground/ForegroundChangedEventArgs.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace WinBGMuter.Abstractions.Foreground
+{
+    public sealed class ForegroundChangedEventArgs : EventArgs
+    {
+        public ForegroundChangedEventArgs(int previousProcessId, int currentProcessId, IntPtr windowHandle, DateTime timestampUtc)
+        {
+            PreviousProcessId = previousProcessId;
+            CurrentProcessId = currentProcessId;
+            WindowHandle = windowHandle;
+            TimestampUtc = timestampUtc;
+        }
+
+        public int PreviousProcessId { get; }
+
+        public int CurrentProcessId { get; }
+
+        public IntPtr WindowHandle { get; }
+
+        public DateTime TimestampUtc { get; }
+    }
+}

--- a/WinBGMute/Abstractions/Foreground/IForegroundTracker.cs
+++ b/WinBGMute/Abstractions/Foreground/IForegroundTracker.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace WinBGMuter.Abstractions.Foreground
+{
+    public interface IForegroundTracker : IDisposable
+    {
+        event EventHandler<ForegroundChangedEventArgs>? ForegroundChanged;
+
+        int CurrentProcessId { get; }
+
+        void Start();
+
+        void Stop();
+    }
+}

--- a/WinBGMute/Abstractions/Media/IMediaController.cs
+++ b/WinBGMute/Abstractions/Media/IMediaController.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace WinBGMuter.Abstractions.Media
+{
+    public interface IMediaController
+    {
+        IReadOnlyCollection<MediaSessionInfo> GetSessions();
+
+        MediaCommandResult TryPause(MediaSessionInfo session);
+
+        MediaCommandResult TryPlay(MediaSessionInfo session);
+    }
+}

--- a/WinBGMute/Abstractions/Media/MediaCommandFailureReason.cs
+++ b/WinBGMute/Abstractions/Media/MediaCommandFailureReason.cs
@@ -1,0 +1,11 @@
+namespace WinBGMuter.Abstractions.Media
+{
+    public enum MediaCommandFailureReason
+    {
+        None = 0,
+        NotSupported,
+        NotFound,
+        Ambiguous,
+        UnknownError
+    }
+}

--- a/WinBGMute/Abstractions/Media/MediaCommandResult.cs
+++ b/WinBGMute/Abstractions/Media/MediaCommandResult.cs
@@ -1,0 +1,28 @@
+namespace WinBGMuter.Abstractions.Media
+{
+    public sealed class MediaCommandResult
+    {
+        public MediaCommandResult(bool success, MediaCommandFailureReason failureReason, string? sessionId)
+        {
+            Success = success;
+            FailureReason = failureReason;
+            SessionId = sessionId;
+        }
+
+        public bool Success { get; }
+
+        public MediaCommandFailureReason FailureReason { get; }
+
+        public string? SessionId { get; }
+
+        public static MediaCommandResult Succeeded(string? sessionId)
+        {
+            return new MediaCommandResult(true, MediaCommandFailureReason.None, sessionId);
+        }
+
+        public static MediaCommandResult Failed(MediaCommandFailureReason reason, string? sessionId)
+        {
+            return new MediaCommandResult(false, reason, sessionId);
+        }
+    }
+}

--- a/WinBGMute/Abstractions/Media/MediaPlaybackState.cs
+++ b/WinBGMute/Abstractions/Media/MediaPlaybackState.cs
@@ -1,0 +1,10 @@
+namespace WinBGMuter.Abstractions.Media
+{
+    public enum MediaPlaybackState
+    {
+        Unknown = 0,
+        Playing,
+        Paused,
+        Stopped
+    }
+}

--- a/WinBGMute/Abstractions/Media/MediaSessionInfo.cs
+++ b/WinBGMute/Abstractions/Media/MediaSessionInfo.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace WinBGMuter.Abstractions.Media
+{
+    public sealed class MediaSessionInfo
+    {
+        public MediaSessionInfo(string sessionId, string? appId, string? displayName, MediaPlaybackState playbackState, DateTime? lastUpdatedUtc)
+        {
+            SessionId = sessionId;
+            AppId = appId;
+            DisplayName = displayName;
+            PlaybackState = playbackState;
+            LastUpdatedUtc = lastUpdatedUtc;
+        }
+
+        public string SessionId { get; }
+
+        public string? AppId { get; }
+
+        public string? DisplayName { get; }
+
+        public MediaPlaybackState PlaybackState { get; }
+
+        public DateTime? LastUpdatedUtc { get; }
+    }
+}

--- a/WinBGMute/Abstractions/Policy/ActionMode.cs
+++ b/WinBGMute/Abstractions/Policy/ActionMode.cs
@@ -1,0 +1,9 @@
+namespace WinBGMuter.Abstractions.Policy
+{
+    public enum ActionMode
+    {
+        PauseOnly = 0,
+        PauseWithMuteFallback,
+        MuteOnly
+    }
+}

--- a/WinBGMute/Abstractions/Policy/IActionPolicy.cs
+++ b/WinBGMute/Abstractions/Policy/IActionPolicy.cs
@@ -1,0 +1,13 @@
+using WinBGMuter.Abstractions.Audio;
+
+namespace WinBGMuter.Abstractions.Policy
+{
+    public interface IActionPolicy
+    {
+        ActionMode Mode { get; }
+
+        bool ShouldAffectProcess(AudioProcessState process);
+
+        bool ShouldResumeProcess(AudioProcessState process);
+    }
+}

--- a/WinBGMute/Abstractions/State/IPlaybackStateStore.cs
+++ b/WinBGMute/Abstractions/State/IPlaybackStateStore.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace WinBGMuter.Abstractions.State
+{
+    public interface IPlaybackStateStore
+    {
+        void MarkPaused(PausedSessionInfo sessionInfo);
+
+        bool TryGetPaused(int processId, out PausedSessionInfo? sessionInfo);
+
+        void Clear(int processId);
+
+        void ClearMissingProcesses(IReadOnlyCollection<int> activeProcessIds);
+    }
+}

--- a/WinBGMute/Abstractions/State/PausedSessionInfo.cs
+++ b/WinBGMute/Abstractions/State/PausedSessionInfo.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace WinBGMuter.Abstractions.State
+{
+    public sealed class PausedSessionInfo
+    {
+        public PausedSessionInfo(int processId, string method, string? sessionKey, DateTime pausedAtUtc)
+        {
+            ProcessId = processId;
+            Method = method;
+            SessionKey = sessionKey;
+            PausedAtUtc = pausedAtUtc;
+        }
+
+        public int ProcessId { get; }
+
+        public string Method { get; }
+
+        public string? SessionKey { get; }
+
+        public DateTime PausedAtUtc { get; }
+    }
+}

--- a/WinBGMute/Audio/AudibilityDetector.cs
+++ b/WinBGMute/Audio/AudibilityDetector.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using WinBGMuter.Abstractions.Audio;
+using WinBGMuter.Logging;
+
+namespace WinBGMuter.Audio
+{
+    /// <summary>
+    /// Determines which processes are currently audible based on Core Audio session snapshots.
+    /// </summary>
+    internal sealed class AudibilityDetector
+    {
+        private readonly float _peakThreshold;
+        private readonly ILogger _logger;
+
+        public AudibilityDetector(float peakThreshold = 0.01f, ILogger? logger = null)
+        {
+            if (peakThreshold < 0 || peakThreshold > 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(peakThreshold), "Peak threshold must be between 0 and 1.");
+            }
+
+            _peakThreshold = peakThreshold;
+            _logger = logger ?? AppLogging.CreateLogger(LogCategories.AudioSessions);
+        }
+
+        /// <summary>
+        /// Returns the set of processes that are considered audible for the given snapshot.
+        /// Multiple sessions from the same process are deduplicated, keeping the loudest peak.
+        /// </summary>
+        public IReadOnlyCollection<AudioProcessState> GetAudibleProcesses(AudioSessionSnapshot snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            var audible = new Dictionary<int, AudioProcessState>();
+
+            foreach (var process in snapshot.Processes)
+            {
+                if (!process.IsActive)
+                {
+                    continue;
+                }
+
+                if (process.Peak < _peakThreshold)
+                {
+                    continue;
+                }
+
+                if (audible.TryGetValue(process.ProcessId, out var existing))
+                {
+                    if (process.Peak > existing.Peak)
+                    {
+                        audible[process.ProcessId] = process;
+                    }
+                }
+                else
+                {
+                    audible[process.ProcessId] = process;
+                }
+            }
+
+            _logger.LogDebug(
+                "Audible at {TimestampUtc}: {Processes}",
+                snapshot.TimestampUtc,
+                FormatProcessList(audible.Values));
+
+            return audible.Values.ToList();
+        }
+
+        private static string FormatProcessList(IEnumerable<AudioProcessState> processes)
+        {
+            return string.Join(", ", processes.Select(p => $"{p.ProcessName}({p.ProcessId}) peak={p.Peak:0.000}"));
+        }
+    }
+}

--- a/WinBGMute/Audio/CoreAudioSessionScanner.cs
+++ b/WinBGMute/Audio/CoreAudioSessionScanner.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using WinBGMuter.Abstractions.Audio;
+using WinBGMuter;
+
+namespace WinBGMuter.Audio
+{
+    /// <summary>
+    /// Provides read-only snapshots of the current Core Audio sessions.
+    /// </summary>
+    internal sealed class CoreAudioSessionScanner : IAudioSessionScanner, IDisposable
+    {
+        private readonly IMMDeviceEnumerator deviceEnumerator;
+        private readonly IMMDevice speakers;
+        private readonly IAudioSessionManager2 sessionManager;
+        private readonly Guid sessionManagerGuid = typeof(IAudioSessionManager2).GUID;
+        private readonly ILogger? logger;
+
+        public CoreAudioSessionScanner(ILogger? logger = null)
+        {
+            this.logger = logger;
+            deviceEnumerator = new MMDeviceEnumerator();
+
+            deviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out speakers);
+            speakers.Activate(ref sessionManagerGuid, 0, IntPtr.Zero, out var sessionManagerObject);
+            sessionManager = (IAudioSessionManager2)sessionManagerObject;
+        }
+
+        public AudioSessionSnapshot CaptureSnapshot()
+        {
+            var timestampUtc = DateTime.UtcNow;
+            var processes = new List<AudioProcessState>();
+
+            sessionManager.GetSessionEnumerator(out var sessionEnumerator);
+            if (sessionEnumerator == null)
+            {
+                return new AudioSessionSnapshot(timestampUtc, processes);
+            }
+
+            try
+            {
+                sessionEnumerator.GetCount(out var sessionCount);
+                for (var index = 0; index < sessionCount; index++)
+                {
+                    IAudioSessionControl2? control = null;
+                    try
+                    {
+                        sessionEnumerator.GetSession(index, out control);
+                        if (control == null)
+                        {
+                            continue;
+                        }
+
+                        control.GetProcessId(out var processId);
+                        var processName = ResolveProcessName(processId);
+
+                        var peak = GetPeak(control);
+                        var isActive = IsActive(control);
+
+                        processes.Add(new AudioProcessState(processId, processName, isActive, peak, timestampUtc));
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogDebug(ex, "Failed to capture audio session at index {Index}", index);
+                    }
+                    finally
+                    {
+                        if (control != null)
+                        {
+                            Marshal.ReleaseComObject(control);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(sessionEnumerator);
+            }
+
+            return new AudioSessionSnapshot(timestampUtc, processes);
+        }
+
+        private static string ResolveProcessName(int processId)
+        {
+            try
+            {
+                return Process.GetProcessById(processId).ProcessName;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static float GetPeak(IAudioSessionControl2 control)
+        {
+            try
+            {
+                if (control is IAudioMeterInformation meter && meter.GetPeakValue(out var peakValue) == 0)
+                {
+                    return peakValue;
+                }
+            }
+            catch
+            {
+                // ignored – metering is best-effort
+            }
+
+            return 0f;
+        }
+
+        private static bool IsActive(IAudioSessionControl2 control)
+        {
+            try
+            {
+                var result = control.GetState(out var state);
+                if (result == 0)
+                {
+                    return state == AudioSessionState.AudioSessionStateActive;
+                }
+            }
+            catch
+            {
+                // ignored – state is best-effort
+            }
+
+            return false;
+        }
+
+        public void Dispose()
+        {
+            Marshal.ReleaseComObject(sessionManager);
+            Marshal.ReleaseComObject(speakers);
+            Marshal.ReleaseComObject(deviceEnumerator);
+        }
+    }
+}

--- a/WinBGMute/Foreground/WinEventForegroundTracker.cs
+++ b/WinBGMute/Foreground/WinEventForegroundTracker.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using WinBGMuter.Abstractions.Foreground;
+using WinBGMuter.Logging;
+
+namespace WinBGMuter.Foreground
+{
+    internal sealed class WinEventForegroundTracker : IForegroundTracker
+    {
+        private const uint EventSystemForeground = 0x0003;
+        private const int ObjidWindow = 0x00000000;
+        private const int ChildIdSelf = 0;
+        private const uint WineventOutofcontext = 0x0000;
+        private const uint WineventSkipownprocess = 0x0002;
+
+        private readonly ILogger _logger;
+        private readonly object _sync = new();
+        private readonly int _debounceIntervalMs;
+
+        private IntPtr _eventHook = IntPtr.Zero;
+        private WinEventProc? _winEventProc;
+        private Timer? _debounceTimer;
+        private int _pendingProcessId = -1;
+        private int _currentProcessId = -1;
+        private bool _started;
+        private bool _disposed;
+
+        public WinEventForegroundTracker(int debounceIntervalMs = 200, ILogger? logger = null)
+        {
+            _debounceIntervalMs = debounceIntervalMs;
+            _logger = logger ?? AppLogging.CreateLogger(LogCategories.Foreground);
+        }
+
+        public event EventHandler<ForegroundChangedEventArgs>? ForegroundChanged;
+
+        public int CurrentProcessId
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _currentProcessId;
+                }
+            }
+        }
+
+        public void Start()
+        {
+            lock (_sync)
+            {
+                ThrowIfDisposed();
+
+                if (_started)
+                {
+                    return;
+                }
+
+                _winEventProc = OnWinEvent;
+                _debounceTimer = new Timer(OnDebounceTimerElapsed, null, Timeout.Infinite, Timeout.Infinite);
+
+                _eventHook = SetWinEventHook(
+                    EventSystemForeground,
+                    EventSystemForeground,
+                    IntPtr.Zero,
+                    _winEventProc,
+                    0,
+                    0,
+                    WineventOutofcontext | WineventSkipownprocess);
+
+                if (_eventHook == IntPtr.Zero)
+                {
+                    _logger.LogError("Failed to register foreground window hook");
+                }
+                else
+                {
+                    _logger.LogInformation("Foreground hook registered with debounce {DebounceMs}ms", _debounceIntervalMs);
+                }
+
+                _currentProcessId = GetForegroundProcessId();
+                _started = true;
+            }
+        }
+
+        public void Stop()
+        {
+            lock (_sync)
+            {
+                if (!_started)
+                {
+                    return;
+                }
+
+                if (_eventHook != IntPtr.Zero)
+                {
+                    UnhookWinEvent(_eventHook);
+                    _eventHook = IntPtr.Zero;
+                }
+
+                _debounceTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+                _debounceTimer?.Dispose();
+                _debounceTimer = null;
+
+                _started = false;
+                _pendingProcessId = -1;
+                _logger.LogInformation("Foreground hook stopped");
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_sync)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                Stop();
+                _disposed = true;
+            }
+        }
+
+        private void OnWinEvent(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
+        {
+            if (eventType != EventSystemForeground || idObject != ObjidWindow || idChild != ChildIdSelf)
+            {
+                return;
+            }
+
+            var processId = GetProcessIdFromWindow(hwnd);
+            if (processId <= 0)
+            {
+                return;
+            }
+
+            lock (_sync)
+            {
+                if (!_started || _disposed)
+                {
+                    return;
+                }
+
+                _pendingProcessId = processId;
+                _debounceTimer?.Change(_debounceIntervalMs, Timeout.Infinite);
+            }
+        }
+
+        private void OnDebounceTimerElapsed(object? state)
+        {
+            int pending;
+            int previous;
+
+            lock (_sync)
+            {
+                if (!_started || _disposed)
+                {
+                    return;
+                }
+
+                pending = _pendingProcessId;
+                previous = _currentProcessId;
+                _pendingProcessId = -1;
+
+                if (pending <= 0 || pending == previous)
+                {
+                    return;
+                }
+
+                _currentProcessId = pending;
+            }
+
+            var args = new ForegroundChangedEventArgs(previous, pending, GetForegroundWindow(), DateTime.UtcNow);
+            _logger.LogInformation("Foreground changed from {PreviousPid} to {CurrentPid}", previous, pending);
+            ForegroundChanged?.Invoke(this, args);
+        }
+
+        private static int GetProcessIdFromWindow(IntPtr hwnd)
+        {
+            _ = GetWindowThreadProcessId(hwnd, out var pid);
+            return unchecked((int)pid);
+        }
+
+        private static int GetForegroundProcessId()
+        {
+            var hwnd = GetForegroundWindow();
+            return hwnd == IntPtr.Zero ? -1 : GetProcessIdFromWindow(hwnd);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(WinEventForegroundTracker));
+            }
+        }
+
+        private delegate void WinEventProc(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
+
+        [DllImport("User32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+        [DllImport("User32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax, IntPtr hmodWinEventProc, WinEventProc? pfnWinEventProc, uint idProcess, uint idThread, uint dwFlags);
+
+        [DllImport("User32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool UnhookWinEvent(IntPtr hWinEventHook);
+
+        [DllImport("User32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr GetForegroundWindow();
+    }
+}

--- a/WinBGMute/Logging/AppLogging.cs
+++ b/WinBGMute/Logging/AppLogging.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+
+namespace WinBGMuter.Logging;
+
+internal static class AppLogging
+{
+    private static LogLevel _minimumLevel = LogLevel.Information;
+
+    private static readonly ILoggerFactory LoggerFactoryInstance = LoggerFactory.Create(builder =>
+    {
+        builder.ClearProviders();
+        builder.AddProvider(new LoggingEngineLoggerProvider(() => _minimumLevel));
+    });
+
+    public static ILoggerFactory LoggerFactory => LoggerFactoryInstance;
+
+    public static ILogger CreateLogger(string categoryName) => LoggerFactory.CreateLogger(categoryName);
+
+    public static ILogger<T> CreateLogger<T>() => LoggerFactory.CreateLogger<T>();
+
+    public static void SetMinimumLevel(LogLevel level)
+    {
+        _minimumLevel = level;
+    }
+
+    public static void SetMinimumLevelFromLegacy(LoggingEngine.LOG_LEVEL_TYPE legacyLevel)
+    {
+        _minimumLevel = ConvertLegacyLevel(legacyLevel);
+    }
+
+    public static LogLevel ConvertLegacyLevel(LoggingEngine.LOG_LEVEL_TYPE legacyLevel) => legacyLevel switch
+    {
+        LoggingEngine.LOG_LEVEL_TYPE.LOG_NONE => LogLevel.None,
+        LoggingEngine.LOG_LEVEL_TYPE.LOG_ERROR => LogLevel.Error,
+        LoggingEngine.LOG_LEVEL_TYPE.LOG_WARNING => LogLevel.Warning,
+        LoggingEngine.LOG_LEVEL_TYPE.LOG_INFO => LogLevel.Information,
+        _ => LogLevel.Debug
+    };
+
+    public static LoggingEngine.LOG_LEVEL_TYPE ConvertToLegacyLevel(LogLevel logLevel) => logLevel switch
+    {
+        LogLevel.Critical => LoggingEngine.LOG_LEVEL_TYPE.LOG_ERROR,
+        LogLevel.Error => LoggingEngine.LOG_LEVEL_TYPE.LOG_ERROR,
+        LogLevel.Warning => LoggingEngine.LOG_LEVEL_TYPE.LOG_WARNING,
+        LogLevel.Information => LoggingEngine.LOG_LEVEL_TYPE.LOG_INFO,
+        LogLevel.Debug => LoggingEngine.LOG_LEVEL_TYPE.LOG_DEBUG,
+        LogLevel.Trace => LoggingEngine.LOG_LEVEL_TYPE.LOG_DEBUG,
+        _ => LoggingEngine.LOG_LEVEL_TYPE.LOG_NONE
+    };
+}

--- a/WinBGMute/Logging/LogCategories.cs
+++ b/WinBGMute/Logging/LogCategories.cs
@@ -1,0 +1,10 @@
+namespace WinBGMuter.Logging;
+
+internal static class LogCategories
+{
+    public const string Foreground = "Foreground";
+    public const string AudioSessions = "AudioSessions";
+    public const string MediaControl = "MediaControl";
+    public const string Policy = "Policy";
+    public const string State = "State";
+}

--- a/WinBGMute/Logging/LoggingEngineLogger.cs
+++ b/WinBGMute/Logging/LoggingEngineLogger.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace WinBGMuter.Logging;
+
+internal sealed class LoggingEngineLogger : ILogger
+{
+    private readonly string _categoryName;
+    private readonly Func<LogLevel> _minimumLevelAccessor;
+
+    public LoggingEngineLogger(string categoryName, Func<LogLevel> minimumLevelAccessor)
+    {
+        _categoryName = categoryName;
+        _minimumLevelAccessor = minimumLevelAccessor;
+    }
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+    {
+        return NullScope.Instance;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return logLevel >= _minimumLevelAccessor();
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) where TState : notnull
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        var message = formatter(state, exception);
+        if (string.IsNullOrEmpty(message) && exception == null)
+        {
+            return;
+        }
+
+        var formattedMessage = $"[{_categoryName}] {logLevel}: {message}";
+
+        if (exception != null)
+        {
+            formattedMessage += $" Exception: {exception}";
+        }
+
+        Debug.WriteLine(formattedMessage);
+
+        if (LoggingEngine.Enabled)
+        {
+            LoggingEngine.LogLine(formattedMessage, loglevel: AppLogging.ConvertToLegacyLevel(logLevel));
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new NullScope();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/WinBGMute/Logging/LoggingEngineLoggerProvider.cs
+++ b/WinBGMute/Logging/LoggingEngineLoggerProvider.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+
+namespace WinBGMuter.Logging;
+
+internal sealed class LoggingEngineLoggerProvider : ILoggerProvider
+{
+    private readonly Func<LogLevel> _minimumLevelAccessor;
+
+    public LoggingEngineLoggerProvider(Func<LogLevel> minimumLevelAccessor)
+    {
+        _minimumLevelAccessor = minimumLevelAccessor;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new LoggingEngineLogger(categoryName, _minimumLevelAccessor);
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/WinBGMute/MainForm.cs
+++ b/WinBGMute/MainForm.cs
@@ -21,6 +21,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Timers;
+using Microsoft.Extensions.Logging;
+using WinBGMuter.Logging;
 
 namespace WinBGMuter
 {
@@ -71,6 +73,8 @@ namespace WinBGMuter
         private bool m_enableDemo = false;
         private int m_errorCount = 0;
         private bool m_isMuteConditionBackground = true;
+
+        private readonly ILogger m_stateLogger = AppLogging.CreateLogger(LogCategories.State);
 
         // @todo untested whether this works
         private static string m_previous_fname = "wininit";
@@ -486,6 +490,7 @@ namespace WinBGMuter
         private void MainForm_Load(object sender, EventArgs e)
         {
             LoggingEngine.LogLevel = LoggingEngine.LOG_LEVEL_TYPE.LOG_DEBUG;
+            AppLogging.SetMinimumLevelFromLegacy(LoggingEngine.LogLevel);
             LoggingEngine.HasDateTime = true;
             LoggingEngine.LogLine("Initializing...");
 
@@ -529,6 +534,8 @@ namespace WinBGMuter
 
 
             this.Text += " - v" + fvi.ProductVersion;
+
+            m_stateLogger.LogInformation("Background Muter UI initialized (file version: {FileVersion}, product version: {ProductVersion})", fvi.FileVersion, fvi.ProductVersion);
 
             m_keepAliveTimer.Elapsed += KeepAliveTimer_Tick;
             m_keepAliveTimer.AutoReset = true;

--- a/WinBGMute/Media/GsmtcMediaController.cs
+++ b/WinBGMute/Media/GsmtcMediaController.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Windows.Media.Control;
+using WinBGMuter.Abstractions.Media;
+using WinBGMuter.Logging;
+
+namespace WinBGMuter.Media
+{
+    internal sealed class GsmtcMediaController : IMediaController
+    {
+        private readonly ILogger _logger;
+        private readonly object _sync = new();
+        private Task<GlobalSystemMediaTransportControlsSessionManager?>? _managerTask;
+
+        public GsmtcMediaController(ILogger? logger = null)
+        {
+            _logger = logger ?? AppLogging.CreateLogger(LogCategories.MediaControl);
+        }
+
+        public IReadOnlyCollection<MediaSessionInfo> GetSessions()
+        {
+            var manager = EnsureManager();
+            if (manager is null)
+            {
+                _logger.LogWarning("GSMTC manager unavailable; returning no sessions");
+                return Array.Empty<MediaSessionInfo>();
+            }
+
+            try
+            {
+                var sessions = manager.GetSessions();
+                var results = sessions.Select(CreateSessionInfo).ToArray();
+
+                _logger.LogDebug("Enumerated {Count} GSMTC sessions", results.Length);
+                return results;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to enumerate GSMTC sessions");
+                return Array.Empty<MediaSessionInfo>();
+            }
+        }
+
+        public MediaCommandResult TryPause(MediaSessionInfo session)
+        {
+            var target = FindSession(session.SessionId);
+            if (target is null)
+            {
+                _logger.LogWarning("Pause failed: session {SessionId} not found", session.SessionId);
+                return MediaCommandResult.Failed(MediaCommandFailureReason.NotFound, session.SessionId);
+            }
+
+            var controls = target.GetPlaybackInfo()?.Controls;
+            if (controls is null || !controls.IsPauseEnabled)
+            {
+                _logger.LogInformation("Pause not supported for session {SessionId}", session.SessionId);
+                return MediaCommandResult.Failed(MediaCommandFailureReason.NotSupported, session.SessionId);
+            }
+
+            try
+            {
+                var result = target.TryPauseAsync().AsTask().GetAwaiter().GetResult();
+                return result
+                    ? MediaCommandResult.Succeeded(session.SessionId)
+                    : MediaCommandResult.Failed(MediaCommandFailureReason.UnknownError, session.SessionId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Pause failed for session {SessionId}", session.SessionId);
+                return MediaCommandResult.Failed(MediaCommandFailureReason.UnknownError, session.SessionId);
+            }
+        }
+
+        public MediaCommandResult TryPlay(MediaSessionInfo session)
+        {
+            var target = FindSession(session.SessionId);
+            if (target is null)
+            {
+                _logger.LogWarning("Play failed: session {SessionId} not found", session.SessionId);
+                return MediaCommandResult.Failed(MediaCommandFailureReason.NotFound, session.SessionId);
+            }
+
+            var controls = target.GetPlaybackInfo()?.Controls;
+            if (controls is null || !controls.IsPlayEnabled)
+            {
+                _logger.LogInformation("Play not supported for session {SessionId}", session.SessionId);
+                return MediaCommandResult.Failed(MediaCommandFailureReason.NotSupported, session.SessionId);
+            }
+
+            try
+            {
+                var result = target.TryPlayAsync().AsTask().GetAwaiter().GetResult();
+                return result
+                    ? MediaCommandResult.Succeeded(session.SessionId)
+                    : MediaCommandResult.Failed(MediaCommandFailureReason.UnknownError, session.SessionId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Play failed for session {SessionId}", session.SessionId);
+                return MediaCommandResult.Failed(MediaCommandFailureReason.UnknownError, session.SessionId);
+            }
+        }
+
+        private GlobalSystemMediaTransportControlsSession? FindSession(string sessionId)
+        {
+            var manager = EnsureManager();
+            if (manager is null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return manager.GetSessions().FirstOrDefault(s => BuildSessionId(s) == sessionId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to access GSMTC sessions while searching for {SessionId}", sessionId);
+                return null;
+            }
+        }
+
+        private GlobalSystemMediaTransportControlsSessionManager? EnsureManager()
+        {
+            Task<GlobalSystemMediaTransportControlsSessionManager?>? managerTask;
+            lock (_sync)
+            {
+                _managerTask ??= InitializeManagerAsync();
+                managerTask = _managerTask;
+            }
+
+            try
+            {
+                return managerTask.GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to acquire GSMTC session manager");
+                return null;
+            }
+        }
+
+        private Task<GlobalSystemMediaTransportControlsSessionManager?> InitializeManagerAsync()
+        {
+            return GlobalSystemMediaTransportControlsSessionManager
+                .RequestAsync()
+                .AsTask()
+                .ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        _logger.LogError(t.Exception, "Failed to request GSMTC session manager");
+                        return null;
+                    }
+
+                    var manager = t.Result;
+                    _logger.LogInformation("GSMTC session manager initialized");
+                    return manager;
+                });
+        }
+
+        private MediaSessionInfo CreateSessionInfo(GlobalSystemMediaTransportControlsSession session)
+        {
+            var playbackInfo = session.GetPlaybackInfo();
+            var playbackState = MapPlaybackState(playbackInfo?.PlaybackStatus);
+            DateTime? lastUpdatedUtc = null;
+
+            var timeline = playbackInfo?.TimelineProperties;
+            if (timeline is not null)
+            {
+                lastUpdatedUtc = timeline.LastUpdatedTime.UtcDateTime;
+            }
+            var displayName = TryGetDisplayName(session);
+
+            return new MediaSessionInfo(
+                BuildSessionId(session),
+                session.SourceAppUserModelId,
+                displayName,
+                playbackState,
+                lastUpdatedUtc);
+        }
+
+        private static MediaPlaybackState MapPlaybackState(GlobalSystemMediaTransportControlsSessionPlaybackStatus? status)
+        {
+            return status switch
+            {
+                GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing => MediaPlaybackState.Playing,
+                GlobalSystemMediaTransportControlsSessionPlaybackStatus.Paused => MediaPlaybackState.Paused,
+                GlobalSystemMediaTransportControlsSessionPlaybackStatus.Stopped => MediaPlaybackState.Stopped,
+                _ => MediaPlaybackState.Unknown,
+            };
+        }
+
+        private string BuildSessionId(GlobalSystemMediaTransportControlsSession session)
+        {
+            if (!string.IsNullOrWhiteSpace(session.SourceAppUserModelId))
+            {
+                return session.SourceAppUserModelId;
+            }
+
+            return $"unknown-{session.GetHashCode().ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        private string? TryGetDisplayName(GlobalSystemMediaTransportControlsSession session)
+        {
+            try
+            {
+                var properties = session.TryGetMediaPropertiesAsync().AsTask().GetAwaiter().GetResult();
+                if (properties is null)
+                {
+                    return null;
+                }
+
+                if (!string.IsNullOrWhiteSpace(properties.Title))
+                {
+                    return properties.Title;
+                }
+
+                if (!string.IsNullOrWhiteSpace(properties.Artist))
+                {
+                    return properties.Artist;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to read media properties for {SessionId}", BuildSessionId(session));
+            }
+
+            return null;
+        }
+    }
+}

--- a/WinBGMute/Program.cs
+++ b/WinBGMute/Program.cs
@@ -17,6 +17,7 @@
 */
 
 using System.Diagnostics;
+using WinBGMuter.Logging;
 
 namespace WinBGMuter
 {
@@ -30,6 +31,13 @@ namespace WinBGMuter
         {
             Process myproc = Process.GetCurrentProcess();
             myproc.PriorityClass = ProcessPriorityClass.BelowNormal;
+
+            AppLogging.SetMinimumLevelFromLegacy(LoggingEngine.LOG_LEVEL_TYPE.LOG_DEBUG);
+
+            var startupLogger = AppLogging.CreateLogger(LogCategories.State);
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+            var version = assembly.GetName().Version?.ToString() ?? "unknown";
+            startupLogger.LogInformation("Starting Background Muter (assembly version: {AssemblyVersion})", version);
 
             ApplicationConfiguration.Initialize();
             Application.Run(new MainForm(args));

--- a/WinBGMute/VolumeMixer.cs
+++ b/WinBGMute/VolumeMixer.cs
@@ -321,11 +321,19 @@ namespace WinBGMuter
     }
 
     [Guid("bfb7ff88-7239-4fc9-8fa2-07c950be9c6d"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal enum AudioSessionState
+    {
+        AudioSessionStateInactive = 0,
+        AudioSessionStateActive = 1,
+        AudioSessionStateExpired = 2
+    }
+
+    [Guid("bfb7ff88-7239-4fc9-8fa2-07c950be9c6d"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     internal interface IAudioSessionControl2
     {
         // IAudioSessionControl
         [PreserveSig]
-        int NotImpl0();
+        int GetState(out AudioSessionState pRetVal);
 
         [PreserveSig]
         int GetDisplayName([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
@@ -366,5 +374,21 @@ namespace WinBGMuter
 
         [PreserveSig]
         int SetDuckingPreference(bool optOut);
+    }
+
+    [Guid("C02216F6-8C67-4B5B-9D00-D008E73E0064"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioMeterInformation
+    {
+        [PreserveSig]
+        int GetPeakValue(out float pfPeak);
+
+        [PreserveSig]
+        int GetMeteringChannelCount(out int pnChannelCount);
+
+        [PreserveSig]
+        int GetChannelsPeakValues(int u32ChannelCount, IntPtr afPeakValues);
+
+        [PreserveSig]
+        int QueryHardwareSupport(out int pdwHardwareSupportMask);
     }
 }

--- a/WinBGMute/WinBGMuter.csproj
+++ b/WinBGMute/WinBGMuter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -20,6 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.SDK.NETRef" Version="10.0.22621.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="res\bgm_muted.ico" />

--- a/WinBGMute/WinBGMuter.csproj
+++ b/WinBGMute/WinBGMuter.csproj
@@ -19,6 +19,9 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="res\bgm_muted.ico" />
   </ItemGroup>
   <ItemGroup>

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,15 @@
+# Glossary
+
+Definitions for terms used in the pause-on-unfocus work.
+
+- **PID (Process ID):** Numeric identifier for a running process, used to correlate foreground windows and audio sessions.
+- **Foreground window:** The window currently receiving user input; retrieved via `GetForegroundWindow()`.
+- **WinEvent hook:** A callback registered with `SetWinEventHook` to receive events such as `EVENT_SYSTEM_FOREGROUND` when the foreground window changes.
+- **Core Audio session:** An audio session returned by `IAudioSessionManager2` / `IAudioSessionEnumerator`; exposes process ID and activity state.
+- **Audible process:** A process whose audio session is active and above a configured peak threshold.
+- **GSMTC (Global System Media Transport Controls):** Windows API surface for media sessions that support play/pause/stop; accessed via `GlobalSystemMediaTransportControlsSessionManager`.
+- **Media session resolver:** Logic that maps a PID to a specific GSMTC media session using heuristics and cached associations.
+- **Policy mode:** Configuration describing what action to apply to background audio (`PauseOnly`, `PauseThenMuteFallback`, `MuteOnly`).
+- **Mute fallback:** Secondary action to silence audio when pause is unsupported or ambiguous.
+- **PausedByUs state:** Tracking record indicating we issued a pause for a given PID, enabling safe resumes only for those processes.
+- **Plugin:** Optional per-application controller (e.g., VLC HTTP interface) that can pause/resume when GSMTC is unavailable.

--- a/docs/pause_on_unfocus_design.md
+++ b/docs/pause_on_unfocus_design.md
@@ -27,6 +27,12 @@ This document captures the behaviour, constraints, and edge cases for adding **p
 4. When focus returns to a PID marked `pausedByUs`, attempt resume (play) if the media session state allows it; clear the flag afterward.
 5. Clear state entries if a process exits or its session disappears.
 
+## Audible detection heuristic
+- Use Core Audio session snapshots to build a per-PID view of activity.
+- A process is considered **audible** when the session reports `IsActive == true` **and** the peak meter is above a configurable
+  threshold (default: `0.01f`).
+- When multiple sessions map to the same PID, keep the loudest peak to represent that PID and avoid duplicate actions.
+
 ## Edge cases
 - **Rapid Alt+Tab:** debounce foreground changes to avoid oscillation.
 - **Manual pause by user:** if the user pauses while focused, do not auto-resume on refocus.

--- a/docs/pause_on_unfocus_design.md
+++ b/docs/pause_on_unfocus_design.md
@@ -1,0 +1,54 @@
+# Pause-on-Unfocus design
+
+This document captures the behaviour, constraints, and edge cases for adding **pause on unfocus** to Background-Muter. The goal is to pause audio apps when they lose focus and resume only when focus returns **if we initiated the pause**.
+
+## Behaviour rules
+- When the foreground window changes, pause any audible background app according to the current policy (pause-only, pause with mute fallback, or mute-only).
+- Resume an app only when both are true:
+  1. We previously paused it (`pausedByUs == true`).
+  2. Its current playback state indicates it can resume (e.g., GSMTC reports paused, not stopped).
+- Never issue a toggle-style command. Always request explicit pause or play operations.
+- If mapping between process and media session is ambiguous or unsupported, prefer **no action** unless mute fallback is enabled.
+
+## Constraints and realities
+- True pause/resume is only supported for apps that expose **Global System Media Transport Controls (GSMTC)**.
+- Apps without GSMTC support require a fallback: mute, or app-specific plugins (e.g., VLC HTTP interface).
+- Foreground tracking must run on the UI user session; Windows services (SYSTEM) cannot control GSMTC reliably.
+- WinEvent hooks must not block; expensive work is dispatched to a background queue.
+- Avoid interrupting communication apps: they should be excluded by default or via user lists.
+
+## Event flow
+1. **Foreground change** detected via `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)`.
+2. Determine the new foreground process ID and fetch the current audible process set from Core Audio session scans.
+3. For each audible PID not matching the foreground:
+   - Apply policy to select an action (pause, pause+mute fallback, or mute).
+   - Attempt to pause via GSMTC using the session resolver; if unsupported and fallback is enabled, mute.
+   - Record `pausedByUs` state only when an action succeeds.
+4. When focus returns to a PID marked `pausedByUs`, attempt resume (play) if the media session state allows it; clear the flag afterward.
+5. Clear state entries if a process exits or its session disappears.
+
+## Edge cases
+- **Rapid Alt+Tab:** debounce foreground changes to avoid oscillation.
+- **Manual pause by user:** if the user pauses while focused, do not auto-resume on refocus.
+- **Process restart / PID reuse:** stored state should be invalidated when the process start time changes.
+- **Multiple active sessions:** if no confident mapping exists, do nothing (or fallback to mute if allowed).
+- **Browser media:** expect coarse control (tab-specific pause is not achievable via GSMTC).
+
+## Configuration surface
+- Mode: `PauseOnly`, `PauseThenMuteFallback`, `MuteOnly`.
+- Lists: included (whitelist) / excluded (blacklist) processes.
+- Thresholds: audio peak threshold, poll interval, foreground debounce, resume grace.
+- Plugin settings: per-app controls (e.g., VLC HTTP host/port/password).
+
+## Logging expectations
+- Startup version and hook registration results.
+- Foreground changes with PIDs and window handles.
+- Decisions per focus change: audible PIDs, chosen action, reason codes (unsupported, ambiguous, excluded, muted fallback).
+- Actions taken: pause/resume/mute successes and failures.
+
+## Acceptance checklist
+- Focus changes emit logs without blocking the hook thread.
+- Spotify/VLC sessions are visible via GSMTC enumeration.
+- Audible PID detection ignores silent but open sessions.
+- Apps we paused resume when focus returns; user-paused apps stay paused.
+- Excluded processes are untouched.


### PR DESCRIPTION
## Summary
- keep debounced foreground detection while adding safer WinEvent hook flags and error handling
- clear and dispose the foreground hook defensively and avoid sharing job queues between instances

## Testing
- dotnet build WinBGMute/WinBGMuter.csproj *(fails: dotnet CLI is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a219b01c83278f0393caf3174660)